### PR TITLE
(xattr -r) Modify run_finish method to improve compatibility with new macOS versions

### DIFF
--- a/spotx.sh
+++ b/spotx.sh
@@ -697,8 +697,8 @@ run_finish() {
   (cd "${xpuiDir}" || exit; zip -qq -r ../xpui.spa .)
   rm -rf "${xpuiDir}"
   [[ "${platformType}" == "macOS" ]] && {
-    [[ "${skipCodesign}" ]] && xattr -cr "${appPath}" 2>/dev/null || { 
-      xattr -cr "${appPath}" 2>/dev/null
+    [[ "${skipCodesign}" ]] && find "${appPath}" -type f -exec xattr -c {} + 2>/dev/null || { 
+      find "${appPath}" -type f -exec xattr -c {} + 2>/dev/null
       codesign -f --deep -s - "${appPath}" 2>/dev/null
       printf "\xE2\x9C\x94\x20\x43\x6F\x64\x65\x73\x69\x67\x6E\x65\x64\x20\x53\x70\x6F\x74\x69\x66\x79\n"
     }


### PR DESCRIPTION
Hello! my name is Longopy.
I've been using your tool for quite some time, and recently I ran into the problem that the script was crashing on new versions of mac os. 
It seems that the `xattr` command no longer has the `-r` option, so the script fails to perform the completion method.

<img width="500" alt="imagen" src="https://github.com/user-attachments/assets/f4fe3690-0d2e-40d5-b390-67b236d5524d" />

I have made a small modification so that this problem does not arise in newer versions, making use of the find command.

I hope it helps, and that nobody else has the same problem.

Best regards.