### PR TITLE
Return Lyrics Button on bottom right corner as per unmodified app

### DIFF
--- a/spotx.sh
+++ b/spotx.sh
@@ -758,7 +758,7 @@ newUiEx=(
 'enableNavAltExperiment2&Enable the new home structure and navigation",values:.,default:.\K.DISABLED&.ENABLED_CENTER&&xpuiJs&1.1.97.956&1.2.2.582'
 'enablePanelSizeCoordination&Enable Panel Size Coordination between the left sidebar, the main view and the right sidebar",default:\K!.(?=})&true&s&xpuiJs&1.2.7.1264&1.2.50.335'
 'enableRightSidebar&Enable the view on the right sidebar",default:\K!1&true&s&xpuiJs&1.1.98.683&1.2.23.1125'
-'enableRightSidebarLyrics&Show lyrics in the right sidebar",default:\K!1&true&s&xpuiJs&1.2.0.1165'
+'enableRightSidebarLyrics&Show lyrics in the right sidebar",default:\K!1&false&s&xpuiJs&1.2.0.1165'
 'enableYLXSidebar&Enable Your Library X view of the left sidebar",default:\K!1&true&s&xpuiJs&1.1.97.962&1.2.13.661'
 )
 podEx=(


### PR DESCRIPTION
The stock and latest version of Spotify from Flatpak has a visible "Show Lyrics" button, represented as a microphone icon, on bottom right corner which opens the lyrics tab on the middle of the app, instead of a "Show Lyrics" on the right side-bar.

This is a more "user-friendly" experience, since the user probably does not want to focus their attention on anything else, for example, looking at track listing, since they should be looking at the lyrics. The current approach has narrow space for a pleasant reading, unless the window is on full size, but even then, it is not that great.

We could have another flag option while applying SpotX-Bash script to allow the user to leave it as stock, if desired, since it removes the microphone toggle icon.